### PR TITLE
[Feat] #4 RabbitMQ 등록 및 엔드포인트 활성화 (#4)

### DIFF
--- a/configserver/build.gradle
+++ b/configserver/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:3.4.3'
+
+	// AMQP
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 }
 
 dependencyManagement {

--- a/configserver/src/main/resources/application.yml
+++ b/configserver/src/main/resources/application.yml
@@ -8,7 +8,8 @@ spring:
     config:
       server:
         git:
-          uri: https://github.com/LGCNS-AM-Camp-PJT1-Team9/resources.git
+#          uri: https://github.com/LGCNS-AM-Camp-PJT1-Team9/resources.git
+          uri: https://github.com/CHEERUP-LEGO/resources.git
           search-paths:
             - eureka-server
             - gateway-server
@@ -17,5 +18,16 @@ spring:
           username: ${GIT_USERNAME}
           password: ${GIT_PW}
           default-label: main
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: guest
+    password: guest
 server:
   port: 8071
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh, health, beans, httptrace, busrefresh

--- a/eurekaserver/src/main/resources/application.yml
+++ b/eurekaserver/src/main/resources/application.yml
@@ -2,4 +2,5 @@ spring:
   application:
     name: eureka-server
   config:
-    import: "optional:configserver:http://config-server:8071"
+#    import: "optional:configserver:http://config-server:8071"
+    import: "optional:configserver:http://localhost:8071"

--- a/gatewayserver/build.gradle
+++ b/gatewayserver/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux:3.4.3'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:3.4.3'
+
+	// AMQP
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 }
 
 dependencyManagement {

--- a/jobbotdari/build.gradle
+++ b/jobbotdari/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka:3.3.4'
+
+	// AMQP
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 }
 
 dependencyManagement {

--- a/jobbotdari/src/main/java/com/team9/jobbotdari/config/AppInitializer.java
+++ b/jobbotdari/src/main/java/com/team9/jobbotdari/config/AppInitializer.java
@@ -13,15 +13,15 @@ public class AppInitializer {
     private final SaraminApiConfig saraminApiConfig;
     private final RecruitmentService recruitmentService;
 
-    @PostConstruct
-    public void init() throws InterruptedException {
-        saraminApiConfig.setCount(15);  // PostConstruct 실행 시 count = 15
-        // 채용 정보 추가
-        recruitmentService.addRecruitment();
-    }
-
-    @EventListener(ApplicationReadyEvent.class)
-    public void afterPostConstruct() {
-        saraminApiConfig.setCount(30);
-    }
+//    @PostConstruct
+//    public void init() throws InterruptedException {
+//        saraminApiConfig.setCount(15);  // PostConstruct 실행 시 count = 15
+//        // 채용 정보 추가
+//        recruitmentService.addRecruitment();
+//    }
+//
+//    @EventListener(ApplicationReadyEvent.class)
+//    public void afterPostConstruct() {
+//        saraminApiConfig.setCount(30);
+//    }
 }

--- a/jobbotdari/src/main/resources/application.yml
+++ b/jobbotdari/src/main/resources/application.yml
@@ -2,4 +2,23 @@ spring:
   application:
     name: jobbotdari
   config:
-    import: "optional:configserver:http://config-server:8071"
+    import: "optional:configserver:http://localhost:8071"
+#    import: "optional:configserver:http://config-server:8071"
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: guest
+    password: guest
+
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/springbootdb?characterEncoding=UTF-8&serverTimeZone=Asia/Seoul
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh, health, beans, httptrace, busrefresh

--- a/jobbotdari_user/build.gradle
+++ b/jobbotdari_user/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	testImplementation 'org.springframework:spring-test'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:3.4.3'
+
+	// AMQP
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 }
 
 dependencyManagement {

--- a/jobbotdari_user/src/main/resources/application.properties
+++ b/jobbotdari_user/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.application.name=jobbotdari-user
-spring.config.import=optional:configserver:http://config-server:8071

--- a/jobbotdari_user/src/main/resources/application.yml
+++ b/jobbotdari_user/src/main/resources/application.yml
@@ -1,11 +1,11 @@
-server:
-  port: 8072
 spring:
   application:
-    name: gateway-server
+    name: jobbotdari-user
+  profiles:
+    active: dev
   config:
     import: "optional:configserver:http://localhost:8071"
-#    import: "optional:configserver:http://config-server:8071"
+#    import: optional:configserver:http://config-server:8071
   rabbitmq:
     host: 127.0.0.1
     port: 5672


### PR DESCRIPTION
### ✨ 작업 내용
- Config Server, Gateway Server 및 각 서비스 서버를 RabbitMQ에 연결
- RabbitMQ에 연결한 서버에 서버 관리를 위한 엔드포인트인 refresh, health, beans, httptrace, busrefresh를 활성화
- 로컬 환경에서 코드를 실행할 수 있도록 일부 코드를 수정(spring.config.import, 데이터베이스 관련 코드)

### ✅ 체크리스트
- [x] 서비스가 RabbitMQ에 연결되는지 확인
- [x] 엔드포인트 활성화 여부 확인 - health 엔드포인트로 확인

### 📌 관련 이슈
- close #1