### PR TITLE
[FIX #3] 로그 데이터 저장 변경 & 서버간 통신 kafka 적용

### DIFF
--- a/jobbotdari/src/main/java/com/team9/jobbotdari/dto/request/CompanyRequestDto.java
+++ b/jobbotdari/src/main/java/com/team9/jobbotdari/dto/request/CompanyRequestDto.java
@@ -2,10 +2,12 @@ package com.team9.jobbotdari.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CompanyRequestDto {
     private String name;

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/kafka/messagequeue/KafkaConsumerConfig.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/kafka/messagequeue/KafkaConsumerConfig.java
@@ -24,8 +24,6 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
-        System.out.println("⚠️ Kafka Consumer 설정 확인: " + props);
-
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/AdminServiceImpl.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/AdminServiceImpl.java
@@ -57,9 +57,10 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public List<LogListResponseDto> getLogs() {
-        Pageable pageable = (Pageable) PageRequest.of(0, 10);
-        Page<Log> logPages = logRepository.findAll(pageable);
-        List<Log> logs = logPages.getContent();
+//        Pageable pageable = (Pageable) PageRequest.of(0, 10);
+//        Page<Log> logPages = logRepository.findAll(pageable);
+//        List<Log> logs = logPages.getContent();
+        List<Log> logs = logRepository.findAll();
 
         return logs.stream()
                 .map(log -> LogListResponseDto.builder()


### PR DESCRIPTION
### ✨ 작업 내용
- 로그 데이터를 에러 로그만 수집하도록 저장 -> db 과부하 방지
- 로그 적재 시 kafka를 이용하여 user 서버에서 적재 수행
- 기업 추가 시 feign 통신 에러 수정

### ✅ 체크리스트
- [x] 로그 데이터 저장 변경
- [x] 서버간 통신 kafka 적용
- [x] 기업 추가 에러 수정

### 📌 관련 이슈
- close #3 